### PR TITLE
Added Multiple Providers and Removed Defaults

### DIFF
--- a/agento/agent.py
+++ b/agento/agent.py
@@ -1,7 +1,7 @@
 from typing import List, Callable
 import json
 
-from agento.settings import DEFAULT_MODEL, DEFAULT_PROVIDER, DEBUG
+from agento.settings import DEBUG
 from agento.engine import execute_python_code, process_results
 from agento.client import ChatMessage, ChatCompletionMessage, chat, add_messages_to_history
 from agento.utils import extract_python_code, load_system_prompt, create_functions_schema, format_agent_name
@@ -12,9 +12,9 @@ AgentFunction = Callable[[str, List[ChatMessage]], List[ChatMessage]]
 def Agent(
         name: str,
         instructions: str,
+        model: str,
+        provider: str,
         functions: List[Callable] = [],
-        model: str = DEFAULT_MODEL,
-        provider: str = DEFAULT_PROVIDER,
         history: List[ChatMessage] = [],
         team: List[AgentFunction] = [],
     ):
@@ -28,9 +28,9 @@ def Agent(
     Args:
         name (str): The name of the agent.
         instructions (str): The instructions for the agent.
-        functions (List[Callable]): The functions that the agent can call.
         model (str): The model to use for the agent.
         provider (str): The provider to use for the agent.
+        functions (List[Callable]): The functions that the agent can call.
         history (List[ChatMessage]): The history of the conversation.
         team (List[AgentFunction]): The team of agents.
 

--- a/agento/agent.py
+++ b/agento/agent.py
@@ -1,7 +1,7 @@
 from typing import List, Callable
 import json
 
-from agento.settings import DEFAULT_MODEL, DEBUG
+from agento.settings import DEFAULT_MODEL, DEFAULT_PROVIDER, DEBUG
 from agento.engine import execute_python_code, process_results
 from agento.client import ChatMessage, ChatCompletionMessage, chat, add_messages_to_history
 from agento.utils import extract_python_code, load_system_prompt, create_functions_schema, format_agent_name
@@ -14,6 +14,7 @@ def Agent(
         instructions: str,
         functions: List[Callable] = [],
         model: str = DEFAULT_MODEL,
+        provider: str = DEFAULT_PROVIDER,
         history: List[ChatMessage] = [],
         team: List[AgentFunction] = [],
     ):
@@ -29,6 +30,7 @@ def Agent(
         instructions (str): The instructions for the agent.
         functions (List[Callable]): The functions that the agent can call.
         model (str): The model to use for the agent.
+        provider (str): The provider to use for the agent.
         history (List[ChatMessage]): The history of the conversation.
         team (List[AgentFunction]): The team of agents.
 
@@ -151,7 +153,7 @@ def Agent(
         history = init_or_update_history(task, history, context_variables)
 
         # Get the response from the chat client
-        response = chat(history, model)
+        response = chat(history, model, provider)
 
         if debug:
             print("-"*50)
@@ -192,7 +194,7 @@ def Agent(
             ))
 
             # Get the response from the chat client
-            response = chat(history, model)
+            response = chat(history, model, provider)
             history.append(ChatMessage(sender=name, message=ChatCompletionMessage(role="assistant", content=response)))
 
         # Return the history

--- a/agento/client.py
+++ b/agento/client.py
@@ -3,7 +3,7 @@ from pydantic import BaseModel
 
 import openai
 
-from agento.settings import PROVIDER_URLS, DEFAULT_PROVIDER
+from agento.settings import PROVIDER_URLS
 
 class ChatCompletionMessage(BaseModel):
     """Wrapper class for a chat message."""
@@ -16,7 +16,7 @@ class ChatMessage(BaseModel):
     message: ChatCompletionMessage
     include_in_chat: bool = True
 
-def chat(messages: List[ChatMessage], model: str, provider: str = DEFAULT_PROVIDER) -> str:
+def chat(messages: List[ChatMessage], model: str, provider: str) -> str:
     """
     Get a chat completion from the specified provider.
 

--- a/agento/client.py
+++ b/agento/client.py
@@ -3,7 +3,7 @@ from pydantic import BaseModel
 
 import openai
 
-from agento.settings import BASE_URL, API_KEY, DEFAULT_MODEL
+from agento.settings import PROVIDER_URLS, DEFAULT_PROVIDER
 
 class ChatCompletionMessage(BaseModel):
     """Wrapper class for a chat message."""
@@ -16,20 +16,26 @@ class ChatMessage(BaseModel):
     message: ChatCompletionMessage
     include_in_chat: bool = True
 
-def chat(messages: List[ChatMessage], model: str = DEFAULT_MODEL) -> str:
+def chat(messages: List[ChatMessage], model: str, provider: str = DEFAULT_PROVIDER) -> str:
     """
-    Get a chat completion from the OpenAI client.
+    Get a chat completion from the specified provider.
 
     Args:
         messages (List[ChatMessage]): The messages to send to the client.
         model (str): The model to use for the completion.
+        provider (str): The provider to use for the completion. Available options: lm_studio, ollama, vllm, openrouter.
 
     Returns:
-        str: The content of the response from the OpenAI client.
+        str: The content of the response from the provider.
     """
+    if provider not in PROVIDER_URLS:
+        raise ValueError(f"Provider {provider} not supported. Available providers: {', '.join(PROVIDER_URLS.keys())}")
+    
+    base_url, api_key = PROVIDER_URLS[provider]
+    
     client = openai.Client(
-        api_key=API_KEY,
-        base_url=BASE_URL,
+        api_key=api_key,
+        base_url=base_url,
     )
     
     response = client.chat.completions.create(

--- a/agento/settings.py
+++ b/agento/settings.py
@@ -19,13 +19,6 @@ PROVIDER_URLS = {
     "openrouter": (OPENROUTER_URL, OPENROUTER_API_KEY),
 }
 
-# Check if the environment variables are set
-if not os.getenv("DEFAULT_MODEL"):
-    print("Warning: Environment variables not set. Using default values.")
-    print("DEFAULT_MODEL:", "Qwen/Qwen2.5-Coder-7B-Instruct")
-
 # Define the settings
 SYSTEM_PROMPT_PATH = "agento/system_prompt.txt"
-DEFAULT_MODEL = os.getenv("DEFAULT_MODEL", "Qwen/Qwen2.5-Coder-7B-Instruct") # Default model for the agent
-DEFAULT_PROVIDER = os.getenv("DEFAULT_PROVIDER", "vllm") # Default provider for the agent
 DEBUG = False # Whether to print debug information

--- a/agento/settings.py
+++ b/agento/settings.py
@@ -4,16 +4,28 @@ import os
 # Load the environment variables from the .env file
 load_dotenv()
 
+# Provider settings
+LM_STUDIO_URL = "http://localhost:1234/v1"
+OLLAMA_URL = "http://localhost:11434/v1"
+VLLM_URL = "http://localhost:8000/v1"
+OPENROUTER_URL = "https://openrouter.ai/api/v1"
+
+OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY", "")
+
+PROVIDER_URLS = {
+    "lm_studio": (LM_STUDIO_URL, ""),
+    "ollama": (OLLAMA_URL, "ollama"),
+    "vllm": (VLLM_URL, ""),
+    "openrouter": (OPENROUTER_URL, OPENROUTER_API_KEY),
+}
+
 # Check if the environment variables are set
-if not (os.getenv("DEFAULT_MODEL") and os.getenv("BASE_URL") and os.getenv("OPENAI_API_KEY")):
+if not os.getenv("DEFAULT_MODEL"):
     print("Warning: Environment variables not set. Using default values.")
-    print("DEFAULT_MODEL:", "qwen2.5-coder:7b-instruct-fp16")
-    print("BASE_URL:", "http://localhost:11434/v1")
-    print("OPENAI_API_KEY:", "ollama")
+    print("DEFAULT_MODEL:", "Qwen/Qwen2.5-Coder-7B-Instruct")
 
 # Define the settings
 SYSTEM_PROMPT_PATH = "agento/system_prompt.txt"
-DEFAULT_MODEL = "qwen2.5-coder:7b-instruct-fp16" # Default model for the agent
-BASE_URL = os.getenv("BASE_URL") if os.getenv("BASE_URL") else "http://localhost:11434/v1" # Base URL for the OpenAI client
-API_KEY = os.getenv("OPENAI_API_KEY") if os.getenv("OPENAI_API_KEY") else "ollama" # API key for the OpenAI client
+DEFAULT_MODEL = os.getenv("DEFAULT_MODEL", "Qwen/Qwen2.5-Coder-7B-Instruct") # Default model for the agent
+DEFAULT_PROVIDER = os.getenv("DEFAULT_PROVIDER", "vllm") # Default provider for the agent
 DEBUG = False # Whether to print debug information

--- a/multi_agent_example.py
+++ b/multi_agent_example.py
@@ -43,17 +43,17 @@ def sell_apples(apples: List[str]) -> str:
 seller_agent = Agent(
     name="Seller Agent",
     instructions="You are an apple seller. You can sell apples.",
+    model="qwen2.5-coder:7b-instruct-fp16",
+    provider="ollama",
     functions=[sell_apples],
-    model="Qwen/Qwen2.5-Coder-7B-Instruct",
-    provider="vllm"
 )
 agent = Agent(
     name="Apple Agent",
     instructions="You can get and eat apples. You can also transfer the task to the seller agent.",
+    model="qwen2.5-coder:7b-instruct-fp16",
+    provider="ollama",
     functions=[get_apples, eat_apples],
     team=[seller_agent],
-    model="Qwen/Qwen2.5-Coder-7B-Instruct",
-    provider="vllm"
 )
 
 history = agent("Can you get 4 apples, eat 1 of them and sell the remaining 3?")

--- a/multi_agent_example.py
+++ b/multi_agent_example.py
@@ -44,12 +44,16 @@ seller_agent = Agent(
     name="Seller Agent",
     instructions="You are an apple seller. You can sell apples.",
     functions=[sell_apples],
+    model="Qwen/Qwen2.5-Coder-7B-Instruct",
+    provider="vllm"
 )
 agent = Agent(
     name="Apple Agent",
     instructions="You can get and eat apples. You can also transfer the task to the seller agent.",
     functions=[get_apples, eat_apples],
     team=[seller_agent],
+    model="Qwen/Qwen2.5-Coder-7B-Instruct",
+    provider="vllm"
 )
 
 history = agent("Can you get 4 apples, eat 1 of them and sell the remaining 3?")

--- a/single_agent_example.py
+++ b/single_agent_example.py
@@ -43,6 +43,8 @@ def sell_apples(apples: List[str]) -> str:
 agent = Agent(
     name="Apple Agent",
     instructions="You are an apple seller. You can get, eat or sell apples.",
+    model="Qwen/Qwen2.5-Coder-7B-Instruct",
+    provider="vllm",
     functions=[get_apples, eat_apples, sell_apples],
 )
 


### PR DESCRIPTION
- Removed `DEFAULT_MODEL`, `BASE_URL` and `API_KEY` defaults from settings and everywhere else
- Now when initialising `Agent`, the user needs to pass the `model` and `provider` parameters 
- Current available providers: `lm_studio`, `vllm`, `ollama`, `openrouter`